### PR TITLE
mythril: add mythril vm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SRC32FLAT=$(SRCBOTH) post.c e820map.c malloc.c romfile.c x86.c optionroms.c \
     hw/pcidevice.c hw/ahci.c hw/pvscsi.c hw/usb-xhci.c hw/usb-hub.c hw/sdcard.c \
     fw/coreboot.c fw/lzmadecode.c fw/multiboot.c fw/csm.c fw/biostables.c \
     fw/paravirt.c fw/shadow.c fw/pciinit.c fw/smm.c fw/smp.c fw/mtrr.c fw/xen.c \
-    fw/acpi.c fw/mptable.c fw/pirtable.c fw/smbios.c fw/romfile_loader.c \
+    fw/mythril.c fw/acpi.c fw/mptable.c fw/pirtable.c fw/smbios.c fw/romfile_loader.c \
     hw/virtio-ring.c hw/virtio-pci.c hw/virtio-blk.c hw/virtio-scsi.c \
     hw/tpm_drivers.c hw/nvme.c
 SRC32SEG=string.c output.c pcibios.c apm.c stacks.c hw/pci.c hw/serialio.c

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -41,6 +41,13 @@ endchoice
         help
             Configure to be used by xen hvmloader, for a HVM guest.
 
+    config MYTHRIL
+        depends on QEMU
+        bool "Support Mythril VM"
+        default y
+        help
+            Configure to be used by mytril loader, for a Mythril guest.
+
     config THREADS
         bool "Parallelize hardware init"
         default y

--- a/src/fw/mythril.c
+++ b/src/fw/mythril.c
@@ -1,0 +1,85 @@
+// Mythril VM Support
+//
+// Copyright (C) 2020 Dan Robertson <daniel.robertson@starlab.io>
+//
+// Authors:
+//  Dan Robertson <daniel.robertson@starlab.io>
+//
+// This file may be distributed under the terms of the GNU LGPLv3 license.
+
+#include "byteorder.h" // be32_to_cpu
+#include "paravirt.h" // PlatformRunningOn
+#include "string.h" // memcpy
+#include "output.h" // dprintf
+#include "util.h" // dprintf
+
+#define INFO_PHYSICAL_ADDR 0x40000000
+
+// TODO(dlrobertson): Do we have other info we want to pass to seabios?
+struct mythril_info {
+    u8 signature[9];
+    void* rsdp;
+};
+
+static struct mythril_info info = {
+    .rsdp = NULL,
+    .signature = {0},
+};
+
+void print_info(int level)
+{
+    if (info.rsdp) {
+        dprintf(level, "mythril_info {\t.rsdp=%p,\t.signature=%s,\t }\n",
+                info.rsdp, info.signature);
+    } else {
+        dprintf(level, "mythril info not found\n");
+    }
+}
+
+void mythril_preinit(void)
+{
+    u8* info_pointer = (u8*)INFO_PHYSICAL_ADDR;
+    u8 tag[9];
+
+    if (!CONFIG_MYTHRIL)
+        return;
+
+    memcpy(tag, info_pointer, 8);
+    tag[8] = '\0';
+    info_pointer += 8;
+
+    // Check if this is a mythril tag
+    if (memcmp(tag, "MYTHRIL ", 8) != 0) {
+        dprintf(3, "incorrect mythril signature! %s\n", tag);
+        return;
+    }
+
+    dprintf(3, "seabios mythril info found\n");
+
+    info.rsdp = info_pointer;
+    memcpy(info.signature, info_pointer, 8);
+
+    // Mythril should give us the RSDP
+    if (memcmp(info.signature, "RSD PTR ", 8) != 0) {
+        dprintf(3, "incorrect rsdp signature!\n");
+        return;
+    }
+
+    // Mythril _always_ creates a XSDT. Both the checksum
+    // and extended checksum should be valid.
+    if (checksum(info.rsdp, 20) || checksum(info.rsdp, 36)) {
+        dprintf(3, "incorrect rsdp checksum!\n");
+        return;
+    }
+
+    print_info(3);
+    PlatformRunningOn = PF_QEMU|PF_MYTHRIL;
+}
+
+
+void mythril_biostable_setup(void) {
+    dprintf(3, "mythril biostable setup\n");
+    if (info.rsdp) {
+        copy_acpi_rsdp(info.rsdp);
+    }
+}

--- a/src/fw/mythril.h
+++ b/src/fw/mythril.h
@@ -1,0 +1,8 @@
+#ifndef __MYTHRIL_H
+#define __MYTHRIL_H
+
+void mythril_preinit(void);
+
+void mythril_biostable_setup(void);
+
+#endif

--- a/src/fw/paravirt.c
+++ b/src/fw/paravirt.c
@@ -25,6 +25,7 @@
 #include "util.h" // pci_setup
 #include "x86.h" // cpuid
 #include "xen.h" // xen_biostable_setup
+#include "mythril.h" // xen_biostable_setup
 #include "stacks.h" // yield
 
 // Amount of continuous ram under 4Gig
@@ -180,6 +181,17 @@ qemu_platform_setup(void)
         mptable_setup();
     }
     smbios_setup();
+
+    if (runningOnMythril()) {
+        dprintf(
+            3,
+            "=====================================\n" \
+            "          Mythril Hypervisor\n" \
+            "=====================================\n" \
+        );
+        mythril_biostable_setup();
+        return;
+    }
 
     if (CONFIG_FW_ROMFILE_LOAD) {
         int loader_err;

--- a/src/fw/paravirt.h
+++ b/src/fw/paravirt.h
@@ -9,6 +9,7 @@
 #define PF_QEMU     (1<<0)
 #define PF_XEN      (1<<1)
 #define PF_KVM      (1<<2)
+#define PF_MYTHRIL  (1<<3)
 
 typedef struct QemuCfgDmaAccess {
     u32 control;
@@ -29,6 +30,9 @@ static inline int runningOnXen(void) {
 }
 static inline int runningOnKVM(void) {
     return CONFIG_QEMU && GET_GLOBAL(PlatformRunningOn) & PF_KVM;
+}
+static inline int runningOnMythril(void) {
+    return CONFIG_MYTHRIL && GET_GLOBAL(PlatformRunningOn) & PF_MYTHRIL;
 }
 
 // Common paravirt ports.

--- a/src/post.c
+++ b/src/post.c
@@ -12,6 +12,7 @@
 #include "e820map.h" // e820_add
 #include "fw/paravirt.h" // qemu_cfg_preinit
 #include "fw/xen.h" // xen_preinit
+#include "fw/mythril.h" // mythril_preinit
 #include "hw/pic.h" // pic_setup
 #include "hw/ps2port.h" // ps2port_setup
 #include "hw/rtc.h" // rtc_write
@@ -328,6 +329,9 @@ handle_post(void)
 
     // Check if we are running under Xen.
     xen_preinit();
+
+    // Check if we are running under Mythril.
+    mythril_preinit();
 
     // Allow writes to modify bios area (0xf0000)
     make_bios_writable();


### PR DESCRIPTION
Add basic mythril support for passing ACPI tables to the guest.
Check for the 8 byte tag `MYTHRIL ` followed by the RSDP at
`0x40000000` if `CONFIG_MYTHRIL` is set. If we find an RSDP
use this RSDP for the guest.